### PR TITLE
remove divider and added fixed logo on navbar

### DIFF
--- a/docs/stylesheets/nokia.css
+++ b/docs/stylesheets/nokia.css
@@ -41,6 +41,19 @@ body, input {
   font-size: .8em;
 }
 
+@media screen and (max-width: 76.1875em) {
+  .md-header__button.md-icon[for=__drawer] {
+    order: -1
+  }
+  .md-header__button.md-logo {
+    display: block;
+  }
+}
+
+.md-container.secondary-section {
+  border: 0;
+}
+
 /* need to have decide if it is better or not
   making the content width bigger
 .md-grid {


### PR DESCRIPTION
Remove horizontal divider (top & bottom) from home page and make logo persistent on navbar irrespective of screen size.